### PR TITLE
feat: range vectors

### DIFF
--- a/src/Contracts/IndexNamespaceInterface.php
+++ b/src/Contracts/IndexNamespaceInterface.php
@@ -5,6 +5,7 @@ namespace Upstash\Vector\Contracts;
 use Upstash\Vector\DataQuery;
 use Upstash\Vector\DataQueryResult;
 use Upstash\Vector\DataUpsert;
+use Upstash\Vector\Iterators\VectorRangeIterator;
 use Upstash\Vector\NamespaceInfo;
 use Upstash\Vector\VectorDeleteResult;
 use Upstash\Vector\VectorFetch;
@@ -13,6 +14,8 @@ use Upstash\Vector\VectorMatch;
 use Upstash\Vector\VectorQuery;
 use Upstash\Vector\VectorQueryManyResult;
 use Upstash\Vector\VectorQueryResult;
+use Upstash\Vector\VectorRange;
+use Upstash\Vector\VectorRangeResult;
 use Upstash\Vector\VectorUpdate;
 use Upstash\Vector\VectorUpsert;
 
@@ -57,4 +60,8 @@ interface IndexNamespaceInterface
     public function random(): ?VectorMatch;
 
     public function update(VectorUpdate $update): void;
+
+    public function range(VectorRange $range): VectorRangeResult;
+
+    public function rangeIterator(VectorRange $range): VectorRangeIterator;
 }

--- a/src/Index.php
+++ b/src/Index.php
@@ -7,6 +7,7 @@ use Upstash\Vector\Contracts\IndexInterface;
 use Upstash\Vector\Contracts\IndexNamespaceInterface;
 use Upstash\Vector\Contracts\TransporterInterface;
 use Upstash\Vector\Exceptions\MissingEnvironmentVariableException;
+use Upstash\Vector\Iterators\VectorRangeIterator;
 use Upstash\Vector\Operations\GetIndexInfoOperation;
 use Upstash\Vector\Operations\ListNamespacesOperation;
 use Upstash\Vector\Operations\ResetAllNamespacesOperation;
@@ -140,5 +141,15 @@ final class Index implements IndexInterface
     public function listNamespaces(): array
     {
         return (new ListNamespacesOperation($this->getTransporter()))->list();
+    }
+
+    public function range(VectorRange $range): VectorRangeResult
+    {
+        return $this->namespace('')->range($range);
+    }
+
+    public function rangeIterator(VectorRange $range): VectorRangeIterator
+    {
+        return $this->namespace('')->rangeIterator($range);
     }
 }

--- a/src/IndexNamespace.php
+++ b/src/IndexNamespace.php
@@ -4,6 +4,7 @@ namespace Upstash\Vector;
 
 use Upstash\Vector\Contracts\IndexNamespaceInterface;
 use Upstash\Vector\Contracts\TransporterInterface;
+use Upstash\Vector\Iterators\VectorRangeIterator;
 use Upstash\Vector\Operations\DeleteNamespaceOperation;
 use Upstash\Vector\Operations\DeleteVectorsOperation;
 use Upstash\Vector\Operations\FetchRandomVectorOperation;
@@ -12,6 +13,7 @@ use Upstash\Vector\Operations\GetNamespaceInfoOperation;
 use Upstash\Vector\Operations\QueryDataOperation;
 use Upstash\Vector\Operations\QueryVectorsManyOperation;
 use Upstash\Vector\Operations\QueryVectorsOperation;
+use Upstash\Vector\Operations\RangeVectorsOperation;
 use Upstash\Vector\Operations\ResetNamespaceOperation;
 use Upstash\Vector\Operations\UpdateVectorOperation;
 use Upstash\Vector\Operations\UpsertDataOperation;
@@ -91,5 +93,15 @@ final readonly class IndexNamespace implements IndexNamespaceInterface
     public function update(VectorUpdate $update): void
     {
         (new UpdateVectorOperation($this->namespace, $this->transporter))->update($update);
+    }
+
+    public function range(VectorRange $range): VectorRangeResult
+    {
+        return (new RangeVectorsOperation($this->namespace, $this->transporter))->range($range);
+    }
+
+    public function rangeIterator(VectorRange $range): VectorRangeIterator
+    {
+        return (new RangeVectorsOperation($this->namespace, $this->transporter))->rangeIterator($range);
     }
 }

--- a/src/Iterators/VectorRangeIterator.php
+++ b/src/Iterators/VectorRangeIterator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Upstash\Vector\Iterators;
+
+use Upstash\Vector\Operations\RangeVectorsOperation;
+use Upstash\Vector\VectorMatch;
+use Upstash\Vector\VectorRange;
+use Upstash\Vector\VectorRangeResult;
+
+/**
+ * @implements \Iterator<string, VectorMatch>
+ */
+class VectorRangeIterator implements \Iterator
+{
+    private string $nextCursor;
+
+    private int $position = 0;
+
+    private array $results = [];
+
+    public function __construct(
+        private readonly RangeVectorsOperation $operation,
+        private VectorRange $range,
+    ) {
+        $rangeResult = $this->operation->range($range);
+        $this->nextCursor = $rangeResult->nextCursor;
+        $this->results = $rangeResult->getResults();
+    }
+
+    public function current(): VectorMatch
+    {
+        return $this->results[$this->position];
+    }
+
+    public function next(): void
+    {
+        $this->position++;
+
+        if ($this->position >= count($this->results) && $this->nextCursor !== '') {
+            $rangeResult = $this->fetchWithCursor($this->nextCursor);
+
+            $this->nextCursor = $rangeResult->nextCursor;
+            $this->results = $rangeResult->getResults();
+            $this->position = 0;
+        }
+
+    }
+
+    public function key(): string
+    {
+        return $this->current()->getIdentifier();
+    }
+
+    public function valid(): bool
+    {
+        if ($this->nextCursor === '' && $this->position >= count($this->results)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function rewind(): void
+    {
+        $rangeResult = $this->fetchWithCursor('0');
+        $this->nextCursor = $rangeResult->nextCursor;
+        $this->position = 0;
+        $this->results = $rangeResult->getResults();
+    }
+
+    private function fetchWithCursor(string $cursor): VectorRangeResult
+    {
+        return $this->operation->range(new VectorRange(
+            limit: $this->range->limit,
+            cursor: $cursor,
+            includeMetadata: $this->range->includeMetadata,
+            includeVectors: $this->range->includeVectors,
+            includeData: $this->range->includeData,
+        ));
+    }
+}

--- a/src/Operations/RangeVectorsOperation.php
+++ b/src/Operations/RangeVectorsOperation.php
@@ -2,15 +2,73 @@
 
 namespace Upstash\Vector\Operations;
 
+use Upstash\Vector\Contracts\TransporterInterface;
+use Upstash\Vector\Iterators\VectorRangeIterator;
+use Upstash\Vector\Operations\Concerns\AssertsApiResponseErrors;
+use Upstash\Vector\Operations\Concerns\MapsVectorMatches;
+use Upstash\Vector\Transporter\ContentType;
+use Upstash\Vector\Transporter\Method;
+use Upstash\Vector\Transporter\TransporterRequest;
+use Upstash\Vector\Transporter\TransporterResponse;
+use Upstash\Vector\VectorRange;
+use Upstash\Vector\VectorRangeResult;
+
 /**
  * @internal
  */
 final readonly class RangeVectorsOperation
 {
+    use AssertsApiResponseErrors;
+    use MapsVectorMatches;
+
     public function __construct(private string $namespace, private TransporterInterface $transporter) {}
 
-    public function range(): void
+    public function range(VectorRange $range): VectorRangeResult
     {
-        // TODO: Implement
+        $request = new TransporterRequest(
+            contentType: ContentType::JSON,
+            method: Method::GET,
+            path: $this->getPath(),
+            data: $range->toArray(),
+        );
+
+        $response = $this->transporter->sendRequest($request);
+
+        $this->assertResponse($response);
+
+        return $this->transformResponse($response, $range);
+    }
+
+    public function rangeIterator(VectorRange $range): VectorRangeIterator
+    {
+        return new VectorRangeIterator($this, $range);
+    }
+
+    private function getPath(): string
+    {
+        $namespace = trim($this->namespace);
+        if ($namespace !== '') {
+            return "/range/$namespace";
+        }
+
+        return '/range';
+    }
+
+    private function transformResponse(TransporterResponse $response, VectorRange $range): VectorRangeResult
+    {
+        $data = json_decode($response->data, true);
+        $result = $data['result'] ?? [];
+
+        $nextCursor = $result['nextCursor'] ?? '0';
+        $vectors = $result['vectors'] ?? [];
+
+        $vectors = array_map(fn (array $vector) => $this->mapVectorMatch($vector), $vectors);
+
+        return new VectorRangeResult(
+            results: $vectors,
+            nextCursor: $nextCursor,
+            originalRange: $range,
+            operation: $this,
+        );
     }
 }

--- a/src/VectorQueryResult.php
+++ b/src/VectorQueryResult.php
@@ -46,9 +46,13 @@ final readonly class VectorQueryResult implements ArrayAccess, Countable, Iterat
         return isset($this->results[$offset]);
     }
 
-    public function offsetGet(mixed $offset): VectorMatch
+    public function offsetGet(mixed $offset): ?VectorMatch
     {
-        return $this->results[$offset];
+        if ($this->offsetExists($offset)) {
+            return $this->results[$offset];
+        }
+
+        return null;
     }
 
     public function offsetSet(mixed $offset, mixed $value): void {}

--- a/src/VectorRange.php
+++ b/src/VectorRange.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Upstash\Vector;
+
+final readonly class VectorRange
+{
+    public function __construct(
+        public int $limit,
+        public string $cursor = '0',
+        public bool $includeMetadata = false,
+        public bool $includeVectors = false,
+        public bool $includeData = false,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'limit' => $this->limit,
+            'cursor' => $this->cursor,
+            'includeMetadata' => $this->includeMetadata,
+            'includeVectors' => $this->includeVectors,
+            'includeData' => $this->includeData,
+        ];
+    }
+}

--- a/src/VectorRangeResult.php
+++ b/src/VectorRangeResult.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Upstash\Vector;
+
+use ArrayAccess;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+use Upstash\Vector\Operations\RangeVectorsOperation;
+
+final readonly class VectorRangeResult implements ArrayAccess, Countable, IteratorAggregate
+{
+    public function __construct(
+        private array $results,
+        public string $nextCursor,
+        private VectorRange $originalRange,
+        private RangeVectorsOperation $operation,
+    ) {}
+
+    public function count(): int
+    {
+        return count($this->results);
+    }
+
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function next(?int $limit = null): VectorRangeResult
+    {
+        $range = new VectorRange(
+            limit: $limit ?? $this->originalRange->limit,
+            cursor: $this->nextCursor,
+            includeMetadata: $this->originalRange->includeMetadata,
+            includeVectors: $this->originalRange->includeVectors,
+            includeData: $this->originalRange->includeData,
+        );
+
+        return $this->operation->range($range);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->results[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): ?VectorMatch
+    {
+        if ($this->offsetExists($offset)) {
+            return $this->results[$offset];
+        }
+
+        return null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    public function offsetUnset(mixed $offset): void {}
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->results);
+    }
+}

--- a/tests/Concerns/MeasuresMemory.php
+++ b/tests/Concerns/MeasuresMemory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Upstash\Vector\Tests\Concerns;
+
+trait MeasuresMemory
+{
+    private function measureMemory(callable $callback): int
+    {
+        $start = memory_get_usage();
+        $callback();
+        $end = memory_get_usage();
+
+        return $end - $start;
+    }
+}

--- a/tests/Dense/Operations/RangeVectorsTest.php
+++ b/tests/Dense/Operations/RangeVectorsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Upstash\Vector\Tests\Dense\Operations;
+
+use PHPUnit\Framework\TestCase;
+use Upstash\Vector\Tests\Concerns\MeasuresMemory;
+use Upstash\Vector\Tests\Concerns\UsesDenseIndex;
+use Upstash\Vector\Tests\Concerns\WaitsForIndex;
+use Upstash\Vector\VectorRange;
+use Upstash\Vector\VectorUpsert;
+
+use function Upstash\Vector\createRandomVector;
+
+class RangeVectorsTest extends TestCase
+{
+    use MeasuresMemory;
+    use UsesDenseIndex;
+    use WaitsForIndex;
+
+    private function generateUpserts(int $count): array
+    {
+        $upserts = [];
+        for ($i = 0; $i < $count; $i++) {
+            $upserts[] = new VectorUpsert(
+                id: (string) $i,
+                vector: createRandomVector(2),
+            );
+        }
+
+        return $upserts;
+    }
+
+    public function test_can_range_vectors(): void
+    {
+        // Arrange
+        $this->namespace->upsertMany($this->generateUpserts(100));
+        $this->waitForIndex($this->namespace);
+
+        $memory = $this->measureMemory(function () {
+            // Act
+            $results = $this->namespace->range(new VectorRange(limit: 10));
+
+            // Assert
+            $this->assertCount(10, $results);
+        });
+
+        // Assert
+        $this->assertLessThan(1024 * 1024, $memory);
+    }
+
+    public function test_can_range_vectors_with_next_helper(): void
+    {
+        // Arrange
+        $this->namespace->upsertMany($this->generateUpserts(100));
+        $this->waitForIndex($this->namespace);
+
+        $memory = $this->measureMemory(function () {
+            // Act
+            $results = $this->namespace->range(new VectorRange(limit: 10));
+
+            // Assert
+            $this->assertCount(10, $results);
+
+            // Act
+            $results = $results->next(limit: 20);
+
+            // Assert
+            $this->assertCount(20, $results);
+        });
+
+        // Assert
+        $this->assertLessThan(1024 * 1024, $memory);
+    }
+
+    public function test_can_range_vectors_using_next_cursor(): void
+    {
+        // Arrange
+        $this->namespace->upsertMany($this->generateUpserts(100));
+        $this->waitForIndex($this->namespace);
+
+        $memory = $this->measureMemory(function () {
+            // Act
+            $results = $this->namespace->range(new VectorRange(limit: 10));
+
+            // Assert
+            $this->assertCount(10, $results);
+
+            // Act
+            $results = $this->namespace->range(new VectorRange(limit: 20, cursor: $results->nextCursor));
+
+            // Assert
+            $this->assertCount(20, $results);
+        });
+
+        // Assert
+        $this->assertLessThan(1024 * 1024, $memory);
+    }
+
+    public function test_can_range_vectors_using_iterator(): void
+    {
+        // Arrange
+        $this->namespace->upsertMany($this->generateUpserts(100));
+        $this->waitForIndex($this->namespace);
+
+        $memory = $this->measureMemory(function () {
+            // Arrange
+            $count = 0;
+
+            // Act
+            $results = $this->namespace->rangeIterator(new VectorRange(limit: 10));
+
+            // Increment count
+            foreach ($results as $result) {
+                $count++;
+            }
+
+            // Second iteration tests rewind
+            foreach ($results as $result) {
+                $count++;
+            }
+
+            // Assert
+            $this->assertSame(200, $count);
+        });
+
+        // Assert
+        $this->assertLessThan(1024 * 1024, $memory);
+    }
+
+    public function test_can_range_vectors_using_iterator_can_break_loop(): void
+    {
+        // Arrange
+        $this->namespace->upsertMany($this->generateUpserts(100));
+        $this->waitForIndex($this->namespace);
+
+        $memory = $this->measureMemory(function () {
+            // Arrange
+            $count = 0;
+
+            // Act
+            $results = $this->namespace->rangeIterator(new VectorRange(limit: 10));
+
+            foreach ($results as $result) {
+                $count++;
+                if ($count === 25) {
+                    break;
+                }
+            }
+
+            // Assert
+            $this->assertSame(25, $count);
+        });
+
+        // Assert
+        $this->assertLessThan(1024 * 1024, $memory);
+    }
+}


### PR DESCRIPTION
This PR includes the ability to range the vector database and also provides an iterator to make the process seamless with foreach.

## Range a vector
You can use the `range()` method to start reading the vector database:
```php
use Upstash\Vector\Index;
use Upstash\Vector\VectorRange;

$index = new Index(url: '', token: '');
$range = $index->range(new VectorRange(limit: 10));

$range->getResults(); // to get the first 10 results
$nextRange = $range->next(); // to get the next range
$nextRange = $range->next(limit: 20); // to get the next range but modify the limit to get next 20 instead of 10
````

## Range a vector using the iterator
You can also use the `rangeIterator()` method to iterate on the results on a foreach, when using this you don't have to worry about calling `next()`, it will be done automatically.
```php
use Upstash\Vector\Index;
use Upstash\Vector\VectorRange;

$index = new Index(url: '', token: '');
$iterator = $index->rangeIterator(new VectorRange(limit: 10));

foreach ($iterator as $match) {
    // $match is an instance of \Upstash\Vector\VectorMatch
}
````