### PR TITLE
fix: upsert many with non-zero arrays was not working

### DIFF
--- a/src/Operations/UpsertDataOperation.php
+++ b/src/Operations/UpsertDataOperation.php
@@ -30,7 +30,7 @@ final readonly class UpsertDataOperation
      */
     public function upsertMany(array $upsert): void
     {
-        $data = array_map(fn (DataUpsert $upsert) => $upsert->toArray(), $upsert);
+        $data = array_map(fn (DataUpsert $upsert) => $upsert->toArray(), array_values($upsert));
         $request = $this->createRequest($data);
 
         $response = $this->transporter->sendRequest($request);

--- a/src/Operations/UpsertVectorOperation.php
+++ b/src/Operations/UpsertVectorOperation.php
@@ -32,7 +32,7 @@ final readonly class UpsertVectorOperation
      */
     public function upsertMany(array $upsert): void
     {
-        $data = array_map(fn (VectorUpsert $upsert) => $upsert->toArray(), $upsert);
+        $data = array_map(fn (VectorUpsert $upsert) => $upsert->toArray(), array_values($upsert));
         $request = $this->createRequest($data);
 
         $response = $this->transporter->sendRequest($request);

--- a/tests/Dense/Operations/UpsertDataTest.php
+++ b/tests/Dense/Operations/UpsertDataTest.php
@@ -40,4 +40,19 @@ class UpsertDataTest extends TestCase
 
         $this->assertSame(3, $info->vectorCount);
     }
+
+    public function test_upsert_many_data_with_non_zero_index_works(): void
+    {
+        $this->namespace->upsertDataMany([
+            1 => new DataUpsert(id: '1', data: 'The capital of Japan is Tokyo'),
+            2 => new DataUpsert(id: '2', data: 'The capital of France is Paris'),
+            3 => new DataUpsert(id: '3', data: 'The capital of Germany is Berlin'),
+        ]);
+
+        $this->waitForIndex($this->namespace);
+
+        $info = $this->namespace->getNamespaceInfo();
+
+        $this->assertSame(3, $info->vectorCount);
+    }
 }

--- a/tests/Dense/Operations/UpsertVectorTest.php
+++ b/tests/Dense/Operations/UpsertVectorTest.php
@@ -47,4 +47,17 @@ class UpsertVectorTest extends TestCase
             vector: [1, 2, 3],
         ));
     }
+
+    public function test_upsert_many_vectors_with_non_zero_index_works(): void
+    {
+        // Act
+        $this->namespace->upsertMany([
+            1 => new VectorUpsert(id: '1', vector: [1, 2]),
+            2 => new VectorUpsert(id: '2', vector: [4, 5]),
+            3 => new VectorUpsert(id: '3', vector: [7, 8]),
+        ]);
+
+        // Assert
+        $this->assertSame(3, $this->namespace->getNamespaceInfo()->vectorCount);
+    }
 }


### PR DESCRIPTION
This PR fixes `upsertMany(...)` and `upsertDataMany(...)`. Passing a non-zero indexed array would create an object instead of an array of upserts to the Vector API.