### PR TITLE
feat: range vectors using an id prefix

### DIFF
--- a/src/Iterators/VectorRangeIterator.php
+++ b/src/Iterators/VectorRangeIterator.php
@@ -76,6 +76,7 @@ class VectorRangeIterator implements Iterator
         return $this->operation->range(new VectorRange(
             limit: $this->range->limit,
             cursor: $cursor,
+            prefix: $this->range->prefix,
             includeMetadata: $this->range->includeMetadata,
             includeVectors: $this->range->includeVectors,
             includeData: $this->range->includeData,

--- a/src/VectorRange.php
+++ b/src/VectorRange.php
@@ -9,6 +9,7 @@ final readonly class VectorRange implements Arrayable
     public function __construct(
         public int $limit,
         public string $cursor = '0',
+        public ?string $prefix = null,
         public bool $includeMetadata = false,
         public bool $includeVectors = false,
         public bool $includeData = false,
@@ -18,6 +19,7 @@ final readonly class VectorRange implements Arrayable
      * @return array{
      *     limit: int,
      *     cursor: string,
+     *     prefix?: string,
      *     includeMetadata: bool,
      *     includeVectors: bool,
      *     includeData: bool,
@@ -25,12 +27,18 @@ final readonly class VectorRange implements Arrayable
      */
     public function toArray(): array
     {
-        return [
+        $data = [
             'limit' => $this->limit,
             'cursor' => $this->cursor,
             'includeMetadata' => $this->includeMetadata,
             'includeVectors' => $this->includeVectors,
             'includeData' => $this->includeData,
         ];
+
+        if ($this->prefix !== null) {
+            $data['prefix'] = $this->prefix;
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
This PR introduces a new property on `VectorRange´ that allows iteration on database records using an id prefix:
```php
$results = $this->namespace->rangeIterator(new VectorRange(limit: 10, prefix: 'prefix-'));
```